### PR TITLE
Introduce proto definitions

### DIFF
--- a/protos/car.proto
+++ b/protos/car.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+
+package pitwall;
+
+option go_package = "protos/pitwall";
+
+message Car {
+  message WorldPosition {
+    float x = 1;
+    float y = 2;
+  };
+  WorldPosition position = 1;
+  // Times are in milliseconds.
+  repeated uint32 lap_times = 2;
+  uint32 current_lap_time = 3;
+
+  // Car's current standing.
+  uint32 race_position = 4;
+};
+
+message Participant {
+  bool ai_controlled = 1;
+  uint32 driver_id = 2;
+  uint32 team_id = 3;
+  uint32 race_number = 4;
+  uint32 nationality_id = 5;
+  string name = 6;
+};
+
+message Session {
+  repeated Participant participants = 1;
+  uint32 type = 2;
+  int32 track_id = 3;
+};

--- a/protos/service.proto
+++ b/protos/service.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package pitwall;
+
+import "protos/car.proto";
+
+option go_package = "protos/pitwall";
+
+service Timings {
+  rpc Session(EmptyRequest) returns (SessionReply) {}
+  rpc RaceUpdates(EmptyRequest) returns (stream CarReply) {}
+};
+
+message EmptyRequest {};
+
+message SessionReply {
+  Session session = 1;
+};
+
+message CarReply {
+  repeated Car cars = 1;
+};


### PR DESCRIPTION
Initial proto definitions for v0.1 design.

These will be used to display car positions and driver rankings in real time for
current session.

